### PR TITLE
Add API to save and restore codec state for pipelining. 

### DIFF
--- a/src/proto/codec/mod.rs
+++ b/src/proto/codec/mod.rs
@@ -369,6 +369,14 @@ impl PacketCodec {
         self.inner.sync_seq_id();
     }
 
+    pub fn front_hack_get_seq_id(&self) -> u8 {
+        self.inner.get_seq_id()
+    }
+
+    pub fn front_hack_set_seq_id(&mut self, id: u8) {
+        self.inner.set_seq_id(id)
+    }
+
     /// Turns compression on.
     pub fn compress(&mut self, level: Compression) {
         self.inner.compress(level);
@@ -430,6 +438,20 @@ impl PacketCodecInner {
         match self {
             PacketCodecInner::Plain(_) => (),
             PacketCodecInner::Comp(c) => c.sync_seq_id(),
+        }
+    }
+
+    fn get_seq_id(&self) -> u8 {
+        match self {
+            PacketCodecInner::Plain(c) => c.seq_id,
+            PacketCodecInner::Comp(c) => c.comp_seq_id,
+        }
+    }
+
+    fn set_seq_id(&mut self, id: u8) {
+        match self {
+            PacketCodecInner::Plain(c) => c.seq_id = id,
+            PacketCodecInner::Comp(c) => c.comp_seq_id = id,
         }
     }
 


### PR DESCRIPTION
The MySQL protocol has a sequence number in each packet, reset to 0 at the start of each command. When pipelining commands, we'll write the packets for the first command, reset the codec, write the packets for the second command, etc.

When we finish flushing the pipeline and try to read the responses, the codec will be in the state corresponding to the last command we wrote, but we'll be reading the response from the _first_ command. This will generally lead to a protocol desync error.

This new API allows the pipelining code to save and restore the parser's sequence number to the appropriate value for each response it reads. I added some basic safeguards to prevent getting/setting the sequence number when not at a packet boundary, but this is fundamentally a hacky, fragile API.